### PR TITLE
Add support for VectorDrawable in BasicWelcomeFragment

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,6 +9,8 @@ android {
         targetSdkVersion 23
         versionCode Integer.parseInt(VERSION_CODE)
         versionName VERSION_NAME
+
+        vectorDrawables.useSupportLibrary = true
     }
 
     buildTypes {

--- a/library/src/main/java/com/stephentuso/welcome/ui/WelcomeActivity.java
+++ b/library/src/main/java/com/stephentuso/welcome/ui/WelcomeActivity.java
@@ -8,6 +8,7 @@ import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.app.AppCompatDelegate;
 import android.view.MenuItem;
 import android.view.View;
 
@@ -39,6 +40,8 @@ public abstract class WelcomeActivity extends AppCompatActivity {
          */
         super.onCreate(null);
         setContentView(R.layout.activity_welcome);
+
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
 
         mAdapter = new WelcomeFragmentPagerAdapter(getSupportFragmentManager());
 

--- a/library/src/main/java/com/stephentuso/welcome/ui/fragments/BasicWelcomeFragment.java
+++ b/library/src/main/java/com/stephentuso/welcome/ui/fragments/BasicWelcomeFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v7.app.AppCompatDelegate;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -62,6 +63,8 @@ public class BasicWelcomeFragment extends Fragment implements WelcomeScreenPage.
             return view;
 
         showParallaxAnim = args.getBoolean(KEY_SHOW_ANIM, showParallaxAnim);
+
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
 
         imageView.setImageResource(args.getInt(KEY_DRAWABLE_ID));
 

--- a/library/src/main/java/com/stephentuso/welcome/ui/fragments/BasicWelcomeFragment.java
+++ b/library/src/main/java/com/stephentuso/welcome/ui/fragments/BasicWelcomeFragment.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.support.v7.app.AppCompatDelegate;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -63,8 +62,6 @@ public class BasicWelcomeFragment extends Fragment implements WelcomeScreenPage.
             return view;
 
         showParallaxAnim = args.getBoolean(KEY_SHOW_ANIM, showParallaxAnim);
-
-        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
 
         imageView.setImageResource(args.getInt(KEY_DRAWABLE_ID));
 


### PR DESCRIPTION
I use `VectorDrawable`s in my project and I noticed they caused issues below Android 5. I looked around found this solution. I am currently using my modified version in my project. If you could merge this (and possibly apply the same logic to your entire project), I'll switch to using your project as an external dependency.

Thanks.