### PR TITLE
Add a fullscreen image page

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile support.v4
     compile support.appcompat
     compile support.preference
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
 }
 
 apply from: '../gradle/bintray.gradle'

--- a/library/src/main/java/com/stephentuso/welcome/FullscreenImagePage.java
+++ b/library/src/main/java/com/stephentuso/welcome/FullscreenImagePage.java
@@ -1,0 +1,20 @@
+package com.stephentuso.welcome;
+
+import androidx.annotation.DrawableRes;
+import androidx.fragment.app.Fragment;
+
+import com.stephentuso.welcome.WelcomePage;
+
+public class FullscreenImagePage extends WelcomePage<FullImagePage> {
+
+    private int drawableResId;
+
+    public FullscreenImagePage(@DrawableRes int drawableResId) {
+        this.drawableResId = drawableResId;
+    }
+
+    @Override
+    protected Fragment fragment() {
+        return WelcomeFullscreenImageFragment.newInstance(this.drawableResId);
+    }
+}

--- a/library/src/main/java/com/stephentuso/welcome/WelcomeFullscreenImageFragment.java
+++ b/library/src/main/java/com/stephentuso/welcome/WelcomeFullscreenImageFragment.java
@@ -1,0 +1,67 @@
+package com.stephentuso.welcome;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import androidx.annotation.DrawableRes;
+import androidx.fragment.app.Fragment;
+
+import com.bumptech.glide.Glide;
+import com.example.wonderland.R;
+import com.stephentuso.welcome.WelcomePage;
+
+public class WelcomeFullscreenImageFragment extends Fragment implements WelcomePage.OnChangeListener {
+
+    private static final String ARG_DRAWABLE_ID = "drawable_id";
+    private int drawableId;
+    private ImageView imageView = null;
+
+
+    public staticWelcomeFullscreenImageFragment newInstance(@DrawableRes int resId) {
+        WelcomeFullImageFragment fragment = new WelcomeFullImageFragment();
+        Bundle args = new Bundle();
+        args.putInt(ARG_DRAWABLE_ID, resId);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.page_image, container, false);
+        imageView = (ImageView) view.findViewById(R.id.wel_image);
+        return view;
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        Bundle args = getArguments();
+        if (args == null)
+            return;
+        drawableId = args.getInt(ARG_DRAWABLE_ID);
+        // I use Glide loading the image
+        Glide.with(view).load(drawableId).into(imageView);
+
+    }
+
+    @Override
+    public void onWelcomeScreenPageScrolled(int pageIndex, float offset, int offsetPixels) {
+        if (Build.VERSION.SDK_INT >= 11 && imageView != null) {
+            imageView.setTranslationX(-offsetPixels * 0.8f);
+        }
+    }
+
+    @Override
+    public void onWelcomeScreenPageSelected(int pageIndex, int selectedPageIndex) {
+
+    }
+
+    @Override
+    public void onWelcomeScreenPageScrollStateChanged(int pageIndex, int state) {
+
+    }
+}

--- a/library/src/main/java/com/stephentuso/welcome/WelcomeFullscreenImageFragment.java
+++ b/library/src/main/java/com/stephentuso/welcome/WelcomeFullscreenImageFragment.java
@@ -31,7 +31,7 @@ public class WelcomeFullscreenImageFragment extends Fragment implements WelcomeP
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.page_image, container, false);
+        View view = inflater.inflate(R.layout.wel_fragment_image, container, false);
         imageView = (ImageView) view.findViewById(R.id.wel_image);
         return view;
     }

--- a/library/src/main/res/layout/wel_fragment_image.xml
+++ b/library/src/main/res/layout/wel_fragment_image.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/wel_image"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+
+</LinearLayout>


### PR DESCRIPTION
Hi, I'm using your fantastic welcome-android to develop welcomPage in my own app. However, the project seems to lack a page to quickly load full-screen images.

[TitleP](https://github.com/stephentuso/welcome-android/issues/49)

TitlePage has a TextView instead of fullscreen image, and images load slowly. FullscreenParallaxPage is not convenient to simply load an image.

Therefore, I develop a FullscreenImagePage and FullscreenImageFragment base on WelcomePage to make afullscreen image as the background of the welcome page which uses the Glide to load image.

By the way, I am an incoming Android engineer and I hope you can give me your valuable advice.

Everything goes well with your work
